### PR TITLE
amazeeio-network implementation:

### DIFF
--- a/bin/pygmy
+++ b/bin/pygmy
@@ -129,6 +129,18 @@ class PygmyBin < Thor
       puts "Error starting haproxy".red
     end
 
+    if Pygmy::DockerNetwork.create
+      puts "Successfully created amazeeio network".green
+    else
+      puts "Error creating amazeeio network".red
+    end
+
+    if Pygmy::DockerNetwork.connect
+      puts "Successfully connected haproxy to amazeeio network".green
+    else
+      puts "Error connecting haproxy to amazeeio network".red
+    end
+
     if Pygmy::Mailhog.start
       puts "Successfully started mailhog".green
     else
@@ -166,6 +178,18 @@ class PygmyBin < Thor
       puts "[*] Haproxy: Running as docker container #{Pygmy::Haproxy.container_name}".green
     else
       puts "[*] Haproxy is not running".red
+    end
+
+    if Pygmy::DockerNetwork.exists?
+      puts "[*] Network: Exists as name #{Pygmy::DockerNetwork.network_name}".green
+    else
+      puts "[*] Network does not exist".red
+    end
+
+    if Pygmy::DockerNetwork.haproxy_connected?
+      puts "[*] Network: Haproxy #{Pygmy::DockerNetwork.haproxy_name} connected to #{Pygmy::DockerNetwork.network_name}".green
+    else
+      puts "[*] Haproxy is not connected to #{Pygmy::DockerNetwork.network_name}".red
     end
 
     if Pygmy::Mailhog.running?

--- a/lib/pygmy/docker_network.rb
+++ b/lib/pygmy/docker_network.rb
@@ -1,0 +1,74 @@
+require_relative 'docker_service'
+
+module Pygmy
+  class DockerNetwork
+    extend Pygmy::DockerService
+
+    def self.network_name
+      'amazeeio-network'
+    end
+
+    def self.haproxy_name
+      'amazeeio-haproxy'
+    end
+
+    def self.create_cmd
+      "docker network create #{self.network_name}"
+    end
+
+    def self.connect_haproxy_cmd
+      "docker network connect #{self.network_name} #{self.haproxy_name}"
+    end
+
+    def self.create
+      unless self.exists?
+        unless Sh.run_command(self.create_cmd).success?
+          raise RuntimeError.new(
+            "Failed to create #{self.network_name}.  Command #{self.run_cmd} failed"
+          )
+        end
+      end
+      self.exists?
+    end
+
+    def self.connect
+      unless self.haproxy_connected?
+        unless Sh.run_command(self.connect_haproxy_cmd).success?
+          raise RuntimeError.new(
+            "Failed to connect #{self.haproxy_name} to #{self.network_name}.  Command #{self.run_cmd} failed"
+          )
+        end
+      end
+      self.haproxy_connected?
+    end
+
+    def self.haproxy_connected?(network_name = self.network_name, haproxy_name = self.haproxy_name)
+      !!(self.inspect_containers(network_name) =~ /#{haproxy_name}/)
+    end
+
+    def self.exists?(network_name = self.network_name)
+      !!(self.ls =~ /#{network_name}/)
+    end
+
+    def self.inspect_containers(network_name = self.network_name)
+      cmd = "docker network inspect #{self.network_name} -f '{{.Containers}}'"
+      ret = Sh.run_command(cmd)
+      if ret.success?
+        return ret.stdout
+      else
+        raise RuntimeError.new("Failure running command '#{cmd}'")
+      end
+    end
+
+    def self.ls
+      cmd = "docker network ls"
+      ret = Sh.run_command(cmd)
+      if ret.success?
+        return ret.stdout
+      else
+        raise RuntimeError.new("Failure running command '#{cmd}'")
+      end
+    end
+
+  end
+end

--- a/lib/pygmy/docker_network.rb
+++ b/lib/pygmy/docker_network.rb
@@ -24,7 +24,7 @@ module Pygmy
       unless self.exists?
         unless Sh.run_command(self.create_cmd).success?
           raise RuntimeError.new(
-            "Failed to create #{self.network_name}.  Command #{self.run_cmd} failed"
+            "Failed to create #{self.network_name}.  Command #{self.create_cmd} failed"
           )
         end
       end
@@ -35,7 +35,7 @@ module Pygmy
       unless self.haproxy_connected?
         unless Sh.run_command(self.connect_haproxy_cmd).success?
           raise RuntimeError.new(
-            "Failed to connect #{self.haproxy_name} to #{self.network_name}.  Command #{self.run_cmd} failed"
+            "Failed to connect #{self.haproxy_name} to #{self.network_name}.  Command #{self.connect_haproxy_cmd} failed"
           )
         end
       end


### PR DESCRIPTION
This solves a problem of docker-compose and amazeeio-haproxy:
Currently all services within docker-compose.yml are added to the bridge network (example: https://github.com/amazeeio/docker/blob/master/example-php56-basic.yml#L29) we need to do that as our haproxy is also in the bridge network and needs to be in the same network as the containers it tries to route too. With that we don't use docker-compose to it's full potential, as docker-compose creates it's own network for all containers, so they can discover each other just with the service name. Adding containers to the bridge network removes this possibility (we fix the issue again with linking the containers together, but overall this is not a nice solution).
This brings multiple issues:
- complexer docker-compose.yml files
- possible container clashes with many containers with the same name.

This pull request does two things:
- Creates a new docker network on start: 'amazeeio-network'
- Connects HAProxy container to this network

Now if we have a docker-compose.yml file and would like our haproxy to route traffic to. We add only the service that needs to be routed *additionally* to the amazeeio-network and the rest can stay the same: service discovery still works, haproxy can route.
Here an example docker-compose.yml

```
version: '2'
services:
  nginx:
    networks:
      - amazeeio-network
      - default
    build: .
    environment:
      - AMAZEEIO_URL=drupal.docker.amazee.io
  php:
    build: .
networks:
  amazeeio-network:
    external: true
```

see how `nginx` is added to the external (not in this docker-compose.yml file created network) `amazeeio-network`. As it is still in the default network, the `nginx` container can easily talk to the `php` container without any linking needed

btw, the whole thing is built with BC in mind, so if we do the old way of adding containers to the `bridge` network, everything will still work, as the haproxy is in both networks