### PR TITLE
Check for several common SSH key files instead of assuming id_rsa

### DIFF
--- a/bin/pygmy
+++ b/bin/pygmy
@@ -64,15 +64,16 @@ class PygmyBin < Thor
     exec_stop({:destroy => true})
   end
 
-  desc 'addkey [~/.ssh/id_rsa]', 'Add additional ssh-key'
+  desc 'addkey [/full/path/to/key_file]', 'Add additional ssh-key'
   long_desc <<-LONGDESC
     Adds an additional ssh key to the ssh-agent.
-    Needs the absolute path to key as an argument
-    or uses ~/.ssh/id_rsa if none provided
+    Needs the absolute path to a key as an argument
+    or looks for common default keyfiles if no
+    argument is provided.
 
-    > $ pygmy addkey [~/.ssh/other_key]
+    > $ pygmy addkey [/full/path/to/key_file]
   LONGDESC
-  def addkey(key = "#{Dir.home}/.ssh/id_rsa")
+  def addkey(key = nil)
     add_ssh_key(key)
   end
 
@@ -148,9 +149,9 @@ class PygmyBin < Thor
     end
 
     if Pygmy::SshAgentAddKey.add_ssh_key
-      puts "Successfully injected ssh key".green
+      puts "Successfully injected ssh key(s)".green
     else
-      puts "Error injected ssh key".red
+      puts "Error injecting ssh key(s)".red
     end
   end
 
@@ -194,9 +195,9 @@ class PygmyBin < Thor
 
     if Pygmy::SshAgent.running?
       if Pygmy::SshAgentAddKey.add_ssh_key(key)
-        puts "Successfully added ssh key".green
+        puts "Successfully added ssh key(s)".green
       else
-        puts "Error added ssh key".red
+        puts "Error adding ssh key(s)".red
       end
     else
       puts "ssh-agent is not running, cannot add key".red

--- a/lib/pygmy/ssh_agent_add_key.rb
+++ b/lib/pygmy/ssh_agent_add_key.rb
@@ -17,7 +17,6 @@ module Pygmy
           "--name=#{Shellwords.escape(self.container_name)} " \
           "#{Shellwords.escape(self.image_name)} " \
           "ssh-add #{key}")
-            puts "Successfully added #{key}".green
             return true
           else
             puts "Error adding #{key}".yellow
@@ -29,13 +28,18 @@ module Pygmy
         end
       else
         suggested_keys = ["id_dsa", "id_rsa", "id_rsa1", "id_ecdsa", "id_ed25519"]
-        success = true
+        success = "unset"
         Dir.glob("#{Dir.home}/.ssh/id_*").each do |f|
           if suggested_keys.include?(File.basename f)
-            success = self.add_ssh_key(f) && success
+            success = !!(self.add_ssh_key(f) && success)
           end
         end
-        return success
+        if success == "unset"
+          puts "No common keys found".yellow
+          return false
+        else
+          return success
+        end
       end
     end
 


### PR DESCRIPTION
If no argument is provided for `pygmy addkey` it will check for a range of common SSH key types (`dsa`/`rsa`/`rsa1`/`ecdsa`/`ed25519`) and attempt to load each, reporting success/failure of each key found, as well as overall success/failure.

Also affects `pygmy up`.