### PR TITLE
Update Amazee docker images upon pygmy update

### DIFF
--- a/bin/pygmy
+++ b/bin/pygmy
@@ -110,6 +110,7 @@ class PygmyBin < Thor
     Pygmy::Haproxy.pull
     Pygmy::Mailhog.pull
     Pygmy::SshAgent.pull
+    Pygmy::Amazee.pull_all
     puts "Done. Recreating containers...".yellow
     exec_stop({:destroy => true})
     exec_up({})

--- a/lib/pygmy/amazee.rb
+++ b/lib/pygmy/amazee.rb
@@ -16,7 +16,11 @@ module Pygmy
     end
 
     def self.ls_cmd
-      cmd = 'docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none | grep -v ssh | grep -v haproxy'
+      # cmd will not ever report non-0 exit codes, but we will
+      # check the results below. This will prevent failures when
+      # there are no amazee images pulled and the update command
+      # is called. To do this, we add ' | cat' to the end of it.
+      cmd = 'docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none | grep -v ssh | grep -v haproxy | cat'
       list = Sh.run_command(cmd)
       unless list.success?
         raise RuntimeError.new(

--- a/lib/pygmy/amazee.rb
+++ b/lib/pygmy/amazee.rb
@@ -16,7 +16,7 @@ module Pygmy
     end
 
     def self.ls_cmd
-      cmd = 'docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none'
+      cmd = 'docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none | grep -v ssh | grep -v haproxy'
       list = Sh.run_command(cmd)
       unless list.success?
         raise RuntimeError.new(

--- a/lib/pygmy/amazee.rb
+++ b/lib/pygmy/amazee.rb
@@ -1,0 +1,38 @@
+require_relative 'docker_service'
+
+module Pygmy
+  class Amazee
+    extend Pygmy::DockerService
+
+    def self.pull(image_name)
+      puts "Pulling Docker Image #{Shellwords.escape(image_name)}".yellow
+      pull_cmd = "docker pull #{Shellwords.escape(image_name)}"
+      success = Sh.run_command(pull_cmd).success?
+      unless success
+        raise RuntimeError.new(
+            "Failed to update #{self.container_name}.  Command #{pull_cmd} failed"
+        )
+      end
+    end
+
+    def self.ls_cmd
+      list = Sh.run_command('docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none')
+      unless list.success?
+        raise RuntimeError.new(
+            "Failed to list amazee docker images.  Command failed"
+        )
+      end
+      list.stdout.split("\n")
+    end
+
+    def self.pull_all
+      list = self.ls_cmd
+      unless list.nil?
+        list.each do |image|
+          pull(image)
+        end
+      end
+    end
+
+  end
+end

--- a/lib/pygmy/amazee.rb
+++ b/lib/pygmy/amazee.rb
@@ -16,10 +16,11 @@ module Pygmy
     end
 
     def self.ls_cmd
-      list = Sh.run_command('docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none')
+      cmd = 'docker image ls --format "{{.Repository}}:{{.Tag}}" | grep amazeeio/ | grep -v none'
+      list = Sh.run_command(cmd)
       unless list.success?
         raise RuntimeError.new(
-            "Failed to list amazee docker images.  Command failed"
+            "Failed to list amazee docker images.  Command #{cmd} failed"
         )
       end
       list.stdout.split("\n")


### PR DESCRIPTION
Closes #20 by introducing image updates based upon the original issue notes.

It will update the images matching 'amazee/*' when `pygmy update` is called, and it will instead treat each one independently, complete with error handling for each available image as well as checks for empty lists.

If the solution is not idea, I would like to work with you to improve it so please provide any feedback you can.