### PR TITLE
Refactoring of start/status/remove processes in bin/pygmy

### DIFF
--- a/bin/pygmy
+++ b/bin/pygmy
@@ -117,20 +117,38 @@ class PygmyBin < Thor
     exec_up({})
   end
 
-  def exec_up(options)
-
-    if options[:resolver]
-      if Pygmy::Dnsmasq.start
-        puts "Successfully started dnsmasq".green
-      else
-        puts "Error starting dnsmasq".red
-      end
-    end
-
-    if Pygmy::Haproxy.start
-      puts "Successfully started haproxy".green
+  def start(service, name)
+    if service.start
+      puts "Successfully started #{name}".green
     else
-      puts "Error starting haproxy".red
+      puts "Error starting #{name}".red
+    end
+  end
+
+  def status(service, name)
+    if service.running?
+      puts "[*] #{name}: Running as docker container #{service.container_name}".green
+    else
+      puts "[*] #{name} is not running".red
+    end
+  end
+
+  def remove(service, name, options)
+    if service.stop
+      puts "#{name} container stopped".green
+      if options[:destroy]
+        if service.delete
+          puts "#{name} container successfully deleted".green
+        else
+          puts "#{name} container failed to delete".red
+        end
+      end
+    else
+      puts "#{name} container failed to stop".red
+    end
+  end
+
+  def exec_up(options)
     end
 
     if Pygmy::DockerNetwork.create

--- a/bin/pygmy
+++ b/bin/pygmy
@@ -194,17 +194,9 @@ class PygmyBin < Thor
 
   def exec_status(_options)
 
-    if Pygmy::Dnsmasq.running?
-      puts "[*] Dnsmasq: Running as docker container #{Pygmy::Dnsmasq.container_name}".green
-    else
-      puts "[*] Dnsmasq is not running".red
-    end
-
-    if Pygmy::Haproxy.running?
-      puts "[*] Haproxy: Running as docker container #{Pygmy::Haproxy.container_name}".green
-    else
-      puts "[*] Haproxy is not running".red
-    end
+    status(Pygmy::Dnsmasq, "Dnsmasq")
+    status(Pygmy::Haproxy, "Haproxy")
+    status(Pygmy::Mailhog, "Mailhog")
 
     if Pygmy::DockerNetwork.exists?
       puts "[*] Network: Exists as name #{Pygmy::DockerNetwork.network_name}".green
@@ -216,12 +208,6 @@ class PygmyBin < Thor
       puts "[*] Network: Haproxy #{Pygmy::DockerNetwork.haproxy_name} connected to #{Pygmy::DockerNetwork.network_name}".green
     else
       puts "[*] Haproxy is not connected to #{Pygmy::DockerNetwork.network_name}".red
-    end
-
-    if Pygmy::Mailhog.running?
-      puts "[*] Mailhog: Running as docker container #{Pygmy::Mailhog.container_name}".green
-    else
-      puts "[*] Mailhog is not running".red
     end
 
     if Pygmy::Resolv.has_our_nameserver?

--- a/bin/pygmy
+++ b/bin/pygmy
@@ -149,7 +149,14 @@ class PygmyBin < Thor
   end
 
   def exec_up(options)
+
+    if options[:resolver]
+      start(Pygmy::Dnsmasq, "dnsmasq")
     end
+
+    start(Pygmy::Haproxy, "haproxy")
+    start(Pygmy::Mailhog, "mailhog")
+    start(Pygmy::SshAgent, "ssh-agent")
 
     if Pygmy::DockerNetwork.create
       puts "Successfully created amazeeio network".green
@@ -161,18 +168,6 @@ class PygmyBin < Thor
       puts "Successfully connected haproxy to amazeeio network".green
     else
       puts "Error connecting haproxy to amazeeio network".red
-    end
-
-    if Pygmy::Mailhog.start
-      puts "Successfully started mailhog".green
-    else
-      puts "Error starting mailhog".red
-    end
-
-    if Pygmy::SshAgent.start
-      puts "Successfully started ssh-agent".green
-    else
-      puts "Error starting ssh-agent".red
     end
 
     if options[:resolver]

--- a/bin/pygmy
+++ b/bin/pygmy
@@ -261,57 +261,10 @@ class PygmyBin < Thor
       puts "Error while removing the resolver".red
     end
 
-    if Pygmy::Dnsmasq.stop
-      puts "Dnsmasq container stopped".green
-      if options[:destroy]
-        if Pygmy::Dnsmasq.delete
-          puts "Dnsmasq container successfully deleted".green
-        else
-          puts "Dnsmasq container failed to delete".red
-        end
-      end
-    else
-      puts "Dnsmasq container failed to stop".red
-    end
-
-    if Pygmy::Mailhog.stop
-      puts "Mailhog container stopped".green
-      if options[:destroy]
-        if Pygmy::Mailhog.delete
-          puts "Mailhog container successfully deleted".green
-        else
-          puts "Mailhog container failed to delete".red
-        end
-      end
-    else
-      puts "Mailhog container failed to stop".red
-    end
-
-    if Pygmy::SshAgent.stop
-      puts "ssh-agent container stopped".green
-      if options[:destroy]
-        if Pygmy::SshAgent.delete
-          puts "ssh-agent container successfully deleted".green
-        else
-          puts "ssh-agent container failed to delete".red
-        end
-      end
-    else
-      puts "ssh-agent container failed to stop".red
-    end
-
-    if Pygmy::Haproxy.stop
-      puts "Haproxy container stopped".green
-      if options[:destroy]
-        if Pygmy::Haproxy.delete
-          puts "Haproxy container successfully deleted".green
-        else
-          puts "Haproxy container failed to delete".red
-        end
-      end
-    else
-      puts "Haproxy container failed to stop".red
-    end
+    remove(Pygmy::Dnsmasq, "Dnsmasq", options)
+    remove(Pygmy::Mailhog, "Mailhog", options)
+    remove(Pygmy::SshAgent, "ssh-agent", options)
+    remove(Pygmy::Haproxy, "Haproxy", options)
 
   end
 end

--- a/bin/pygmy
+++ b/bin/pygmy
@@ -117,6 +117,11 @@ class PygmyBin < Thor
     exec_up({})
   end
 
+  # start unifies the process of starting a container
+  # in the standardized format and includes the error
+  # handling.
+  # * service is the service class (ie Pygmy::Haproxy)
+  # * name is the human readable name for output
   def start(service, name)
     if service.start
       puts "Successfully started #{name}".green
@@ -125,6 +130,10 @@ class PygmyBin < Thor
     end
   end
 
+  # status unifies the process of reporting the status
+  # of a container in the standardized format and
+  # includes the error handling.
+  # * service is the service class (ie Pygmy::Haproxy)
   def status(service, name)
     if service.running?
       puts "[*] #{name}: Running as docker container #{service.container_name}".green
@@ -133,6 +142,12 @@ class PygmyBin < Thor
     end
   end
 
+  # remove unifies the process of removing a container
+  # in the standardized format and includes the error
+  # handling.
+  # * service is the service class (ie Pygmy::Haproxy)
+  # * name is the human readable name for output
+  # * options is the options passed to pygmy on execution
   def remove(service, name, options)
     if service.stop
       puts "#{name} container stopped".green


### PR DESCRIPTION
I've been doing some work with pygmy lately, understanding how some things have been designed and putting my own services in place.

I've noticed some repetition which would could easily be remediated, so instead of copy and pasting for new services, such as portainer or traefik as I'm working on independently I thought you might have some interested in this.

It's basic, but it does improve the elegance of the tool - at least in the places it can be used.

* Streamlined functions for patterns used for container start, state and kill processes
* Added comments for these functions
* Updates relevant calls to these processes to use the new functions