### PR TITLE
Support for Windows platform (via PowerShell)

### DIFF
--- a/lib/pygmy/resolv.rb
+++ b/lib/pygmy/resolv.rb
@@ -44,6 +44,9 @@ module Pygmy
 
 
     def self.configure
+      if Gem.win_platform?
+        return ResolvWin.create_resolver?
+      end
       if Linux.osx?
         return ResolvOsx.create_resolver?
       end
@@ -63,6 +66,9 @@ module Pygmy
     end
 
     def self.clean
+      if Gem.win_platform?
+        return ResolvWin.clean?
+      end
       if Linux.osx?
         return ResolvOsx.clean?
       end
@@ -86,6 +92,9 @@ module Pygmy
     end
 
     def self.has_our_nameserver?
+      if Gem.win_platform?
+        return ResolvWin.resolver_status?
+      end
       if Linux.osx?
         return ResolvOsx.resolver_file_exists?
       end

--- a/lib/pygmy/resolv_win.rb
+++ b/lib/pygmy/resolv_win.rb
@@ -1,0 +1,44 @@
+require 'colorize'
+
+module Pygmy
+  module ResolvWin
+
+    def self.domain
+      "docker.amazee.io"
+    end
+
+    def self.create_command
+      "Set-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters -Name Domain -Value #{self.domain}"
+    end
+
+    def self.remove_command
+      "Clear-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters -Name Domain"
+    end
+
+    def self.status_command
+      "Get-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters"
+    end
+
+    def self.create_resolver?
+      puts "setting up DNS resolution".green
+      PowerShell.run_command(self.create_command)
+    end
+
+    def self.clean?
+      puts "Removing DNS configuration".green
+      PowerShell.run_command(self.remove_command)
+    end
+
+    def self.resolver_status?
+      status_command = PowerShell.run_command(self.status_command)
+      lines = status_command.stdout.split("\n")
+      lines.each do |line|
+        if line.start_with?("Domain") and line.include?("#{self.domain}")
+          return true
+        end
+      end
+      false
+    end
+
+  end
+end

--- a/lib/pygmy/shell.rb
+++ b/lib/pygmy/shell.rb
@@ -22,4 +22,15 @@ module Pygmy
       })
     end
   end
+
+  module PowerShell
+    def self.run_command(command)
+      stdout = `powershell #{command}`
+      OpenStruct.new({
+        success?: $?.exitstatus == 0,
+        exitstatus: $?.exitstatus,
+        stdout: stdout
+      })
+    end
+  end
 end

--- a/lib/pygmy/ssh_agent_add_key.rb
+++ b/lib/pygmy/ssh_agent_add_key.rb
@@ -9,13 +9,20 @@ module Pygmy
     end
 
     def self.add_ssh_key(key = "#{Dir.home}/.ssh/id_rsa")
+      if Gem.win_platform?
+        key_agent = "windows-key-add"
+        key_destination = "/key"
+      else
+        key_agent = "ssh-add"
+        key_destination = "/#{key}"
+      end
       if File.file?(key)
         system("docker run --rm -it " \
-        "--volume=#{key}:/#{key} " \
+        "--volume=#{key}:#{key_destination} " \
         "--volumes-from=amazeeio-ssh-agent " \
         "--name=#{Shellwords.escape(self.container_name)} " \
         "#{Shellwords.escape(self.image_name)} " \
-        "ssh-add #{key}")
+        "#{key_agent} #{key_destination}")
       else
         puts "ssh key: #{key}, does not exist, ignoring...".yellow
         return false


### PR DESCRIPTION
This PR resolves #23.

I've gone through and made some changes to suit complete compatibility with the most coarse variety of Windows shell - PowerShell. A lot of customers of my employer who utilize pygmy are stuck with Windows which currently has a fragmented toolset which isn't as streamlined or as easy as any variety of Linux including Darwin.

Happy to hear feedback and make adjustments as recommended

The main issues handled included the resolver and SSH keys.

This has been thoroughly tested by myself and another over the past couple of days and I can organize more tests and/or testers if needed.

Note my `hosts` file is unchanged on both `WSL` and `Windows` in testing this change.

## Resolver

The main issue was providing a suitable and able alternative to the resolver used for Linux and Mac. Applying a common interface copied from the Osx resolver helped achieve this. A PowerShell registry change was needed in this, so the commands were contained in function return values and a PowerShell abstraction layer was imposed to centralize the API for this in the same way as Shell and Bash.

## SSH Keys

A simple checker to introduce two new variables for use with the add-key process which copies functionality conditionally from `amazeeio/amazeeio-docker-windows`.

https://github.com/amazeeio/amazeeio-docker-windows/blob/master/ssh-key-add.cmd#L15