### PR TITLE
Allow rudimentary port configuration

### DIFF
--- a/bin/pygmy
+++ b/bin/pygmy
@@ -31,6 +31,7 @@ class PygmyBin < Thor
   LONGDESC
   option :addkey, type: :boolean, default:true
   option :resolver, type: :boolean, default: true
+  option :port, type: :string, default: "80"
   def up
     exec_up(options)
   end
@@ -90,6 +91,7 @@ class PygmyBin < Thor
     > $ pygmy restart [-d|--destroy]
   LONGDESC
   option :destroy, type: :boolean, aliases: '-d', default: false
+  option :port, type: :string, default: "80"
   def restart
     exec_stop(options)
     exec_up(options)
@@ -120,15 +122,20 @@ class PygmyBin < Thor
 
   def exec_up(options)
 
+    if options[:port] != "80" && options[:port] != "443"
+      puts "Incompatible port '#{options[:port]}' was used for input --port, please use 80 or 443."
+      exit
+    end
+
     if options[:resolver]
-      if Pygmy::Dnsmasq.start
+      if Pygmy::Dnsmasq.start(options)
         puts "Successfully started dnsmasq".green
       else
         puts "Error starting dnsmasq".red
       end
     end
 
-    if Pygmy::Haproxy.start
+    if Pygmy::Haproxy.start(options)
       puts "Successfully started haproxy".green
     else
       puts "Error starting haproxy".red
@@ -146,13 +153,13 @@ class PygmyBin < Thor
       puts "Error connecting haproxy to amazeeio network".red
     end
 
-    if Pygmy::Mailhog.start
+    if Pygmy::Mailhog.start(options)
       puts "Successfully started mailhog".green
     else
       puts "Error starting mailhog".red
     end
 
-    if Pygmy::SshAgent.start
+    if Pygmy::SshAgent.start(options)
       puts "Successfully started ssh-agent".green
     else
       puts "Error starting ssh-agent".red

--- a/lib/pygmy/docker_service.rb
+++ b/lib/pygmy/docker_service.rb
@@ -2,12 +2,12 @@ require 'shellwords'
 
 module Pygmy
   module DockerService
-    def start
+    def start(options)
       unless self.running?
         success = if self.container_exists?
                     Sh.run_command(self.start_cmd).success?
                   else
-                    Sh.run_command(self.run_cmd).success?
+                    Sh.run_command(self.run_cmd(options)).success?
                   end
         unless success
           raise RuntimeError.new(

--- a/lib/pygmy/haproxy.rb
+++ b/lib/pygmy/haproxy.rb
@@ -12,9 +12,9 @@ module Pygmy
       'amazeeio-haproxy'
     end
 
-    def self.run_cmd
+    def self.run_cmd(options)
       "docker run -d " \
-      "-p 80:80 -p 443:443 " \
+      "-p #{options[:port]}:#{options[:port]} " \
       "--volume=/var/run/docker.sock:/tmp/docker.sock " \
       "--restart=always " \
       "--name=#{Shellwords.escape(self.container_name)} " \

--- a/lib/pygmy/ssh_agent.rb
+++ b/lib/pygmy/ssh_agent.rb
@@ -12,7 +12,7 @@ module Pygmy
       'amazeeio-ssh-agent'
     end
 
-    def self.run_cmd
+    def self.run_cmd(options)
       "docker run -d " \
       "--restart=always " \
       "--name=#{Shellwords.escape(self.container_name)} " \


### PR DESCRIPTION
Resolves #46 

Ports can be opened up here, however there's a hard limitation imposed that the port must be either `80` or `443` as part of the standard HAproxy configuration.

I know there's some that have asked for this, and it's pretty safe and secure but feel free to give feedback if you have interest in merging this one.