### PR TITLE
Docs Troubleshooting common ssh-agent problem after update

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,6 +202,29 @@ Example `hosts` file contents:
 
     10.0.2.2 my-local-website.com.docker.amazee.io
 
+### I get an error like `no such service: amazeeio-ssh-agent` when using `docker-compose up` even after pygmy started fine
+
+Restart pygmy and make sure that pygmy could start the ssh-agent container.
+
+    pygmy restart
+    pygmy status
+
+You could see a message like this:
+
+    [*] ssh-agent: Running as docker container amazeeio-ssh-agent, loaded keys:
+    The agent has no identities.
+
+If you have recently updated Docker Desktop you should ensure that your turn off Docker Compose v2 support.
+
+1. Open Docker Desktop Preferences
+1. Uncheck the option labelled "Use Docker Compose v2"
+1. Click Apply and Restart
+
+Once completed, try starting pygmy and run your `docker-compose up` commands again.
+
+    pygmy up
+    docker-compose up
+
 ## pygmy
 
 Most issues with `pygmy` can be resolved with:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,16 +247,16 @@ If during starting of `pygmy` you see an error like that:
         Error starting userland proxy: listen tcp 0.0.0.0:53: bind: address already in use
         Error: failed to start containers: amazeeio-dnsmasq
 
-You are probably on Ubuntu and the by default started DNS server by Ubuntu conflicts with the one we provide with `pygmy`. The resolution depends on Ubuntu version.  
+You are probably on Ubuntu and the by default started DNS server by Ubuntu conflicts with the one we provide with `pygmy`. The resolution depends on Ubuntu version.
 
 #### Ubuntu before 18.04
 You should disable it, see here: http://askubuntu.com/a/233223 (no worries, the default started DNS server is actually not used, so it's safe to disable it).
 
 #### Ubuntu 18.04 and later
-You should disable it as described https://mmoapi.com/post/how-to-disable-dnsmasq-port-53-listening-on-ubuntu-18-04.  
+You should disable it as described https://mmoapi.com/post/how-to-disable-dnsmasq-port-53-listening-on-ubuntu-18-04.
 Instead of reboot the system, remove */etc/resolv.conf*  file (still symlinking to a systemd-resolved file) and create an empty one.
 
-    sudo rm /etc/resolv.conf  
+    sudo rm /etc/resolv.conf
     sudo touch /etc/resolv.conf
 
 If you still run into the error run following command `sudo netstat -tulpn` to see the processlist look for the service running on port 53 (you should find that process in the `Local Address` column). Look for the Process ID (PID)


### PR DESCRIPTION
## Motivation

This problem has come up for my team on multiple occasions. Adding help to the troubleshooting docs page for `ssh-agent` issue on macOS where keys are not loaded. Happens often after a system or Docker Desktop update.